### PR TITLE
refactor: replace client.fetch with sanityFetch for live data updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "schema": "npx sanity@latest schema extract",
-    "types": "npx sanity@latest typegen generate"
+    "types": "npx sanity@latest typegen generate",
+    "typegen": "npx sanity@latest schema extract && npx sanity@latest typegen generate --enforce-required-fields"
   },
   "dependencies": {
     "@sanity/client": "^7.3.0",

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -6,32 +6,21 @@ import { SanityLive } from '@/sanity/lib/live';
 import { DisableDraftMode } from '@/components/DisableDraftMode';
 import Footer from '@/components/Footer/Footer';
 import Header from '@/components/Header/Header';
-import { token } from '@/sanity/lib/token';
 import { fetchFooter, fetchHome } from '@/sanity/lib/queries';
 import { FetchHomeResult } from '../../../sanity.types';
-import { client } from '@/sanity/lib/client';
+import { sanityFetch } from '@/sanity/lib/live';
 
 export default async function HomeLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const { isEnabled } = await draftMode();
+  const { data }: { data: FetchHomeResult } = await sanityFetch({
+    query: fetchHome,
+    params: { slug: '/' },
+  });
 
-  const data: FetchHomeResult = await client.fetch(
-    fetchHome,
-    { slug: '/' },
-    isEnabled
-      ? {
-          perspective: 'previewDrafts',
-          useCdn: false,
-          stega: true,
-          token: token,
-        }
-      : undefined
-  );
-
-  const footer = await client.fetch(fetchFooter);
+  const { data: footer } = await sanityFetch({ query: fetchFooter });
   const hasMultipleBlocks = (data?.blockList?.length || 0) > 1;
 
   return (

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -9,6 +9,8 @@ import ImageWithText from '@/components/Blocks/ImageWithText';
 import LogoCarousel from '@/components/Blocks/LogoCarousel';
 import PageTitle from '@/components/Blocks/PageTitle';
 import MoviesHeroCarousel from '@/components/Blocks/MoviesHeroCarousel';
+import JsonLd from '@/components/JsonLd';
+import { getOrganizationJsonLd } from '@/utils/jsonld';
 
 export { generateMetadata };
 
@@ -24,36 +26,47 @@ export default async function HomePage() {
 
   if (!data || !data.blockList) return null;
 
+  // JSON-LD structured data for Organization
+  const orgJsonLd = getOrganizationJsonLd({
+    name: data.pageTitle || 'PH Film Media',
+    url:
+      process.env.NEXT_PUBLIC_SANITY_STUDIO_PREVIEW_URL ||
+      'http://localhost:3000',
+  });
+
   const firstBlock = data.blockList[0];
   const isHero =
     firstBlock && '_type' in firstBlock && firstBlock._type === 'heroCarousel';
 
   return (
-    <div
-      className={`grid grid-cols-1 gap-8 pt-52 ${isHero ? 'lg:pt-0' : 'lg:pt-48'}`}
-    >
-      {data.blockList.map((block: IHomePageBlockListItem, idx) => {
-        if (!block || !('_type' in block)) return null;
+    <>
+      <JsonLd data={orgJsonLd} />
+      <div
+        className={`grid grid-cols-1 gap-8 pt-52 ${isHero ? 'lg:pt-0' : 'lg:pt-48'}`}
+      >
+        {data.blockList.map((block: IHomePageBlockListItem, idx) => {
+          if (!block || !('_type' in block)) return null;
 
-        switch (block._type) {
-          case 'heroCarousel':
-            return <HeroCarouselBlock key={idx} block={block} idx={idx} />;
-          case 'pageTitle':
-            return <PageTitle key={idx} {...block} />;
-          case 'mediaCarousel':
-            return <MediaCarousel key={idx} {...block} />;
-          case 'movieClubList':
-            return <MovieClubList key={idx} {...block} />;
-          case 'moviesHeroCarousel':
-            return <MoviesHeroCarousel key={idx} {...block} />;
-          case 'imageWithText':
-            return <ImageWithText key={idx} {...block} />;
-          case 'logoCarousel':
-            return <LogoCarousel key={idx} {...block} />;
-          default:
-            return null;
-        }
-      })}
-    </div>
+          switch (block._type) {
+            case 'heroCarousel':
+              return <HeroCarouselBlock key={idx} block={block} idx={idx} />;
+            case 'pageTitle':
+              return <PageTitle key={idx} {...block} />;
+            case 'mediaCarousel':
+              return <MediaCarousel key={idx} {...block} />;
+            case 'movieClubList':
+              return <MovieClubList key={idx} {...block} />;
+            case 'moviesHeroCarousel':
+              return <MoviesHeroCarousel key={idx} {...block} />;
+            case 'imageWithText':
+              return <ImageWithText key={idx} {...block} />;
+            case 'logoCarousel':
+              return <LogoCarousel key={idx} {...block} />;
+            default:
+              return null;
+          }
+        })}
+      </div>
+    </>
   );
 }

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,7 +1,5 @@
-import { draftMode } from 'next/headers';
-import { client } from '@/sanity/lib/client';
-import { fetchAllPageSlugs, fetchHome } from '@/sanity/lib/queries';
-import { token } from '@/sanity/lib/token';
+import { sanityFetch } from '@/sanity/lib/live';
+import { fetchHome } from '@/sanity/lib/queries';
 import { generateMetadata } from '@/utils/generateMetadata';
 import { FetchHomeResult } from '../../../sanity.types';
 import HeroCarouselBlock from '@/components/Blocks/HeroCarousel/index';
@@ -18,25 +16,11 @@ type IHomePageBlockListItem = NonNullable<
   NonNullable<FetchHomeResult>['blockList']
 >[number];
 
-export async function generateStaticParams() {
-  const slugs = await client.fetch(fetchAllPageSlugs);
-  return slugs.map(({ slug }) => ({ slug }));
-}
-
 export default async function HomePage() {
-  const { isEnabled } = await draftMode();
-  const data: FetchHomeResult = await client.fetch(
-    fetchHome,
-    { slug: '/' },
-    isEnabled
-      ? {
-          perspective: 'previewDrafts',
-          useCdn: false,
-          stega: true,
-          token: token,
-        }
-      : undefined
-  );
+  const { data }: { data: FetchHomeResult } = await sanityFetch({
+    query: fetchHome,
+    params: { slug: '/' },
+  });
 
   if (!data || !data.blockList) return null;
 

--- a/src/app/(page)/[slug]/[movieSlug]/page.tsx
+++ b/src/app/(page)/[slug]/[movieSlug]/page.tsx
@@ -1,17 +1,7 @@
-import { client } from '@/sanity/lib/client';
+import { sanityFetch } from '@/sanity/lib/live';
 import { notFound } from 'next/navigation';
-import { draftMode } from 'next/headers';
-import {
-  fetchDistributionMovie,
-  settingsQuery,
-  fetchAllDistributionMovieSlugs,
-  fetchDistributionParentSlug,
-} from '@/sanity/lib/queries';
-import { token } from '@/sanity/lib/token';
-import {
-  FetchDistributionMovieResult,
-  SettingsQueryResult,
-} from '../../../../../sanity.types';
+import { fetchDistributionMovie, settingsQuery } from '@/sanity/lib/queries';
+import { FetchDistributionMovieResult } from '../../../../../sanity.types';
 import { generateMetadata } from '@/utils/generateMetadata';
 import MovieDetailHero from '@/components/Blocks/DistributionList/DistributionMovieDetail/MovieDetailHero';
 import MovieDetail from '@/components/Blocks/DistributionList/DistributionMovieDetail/MovieDetail';
@@ -22,40 +12,15 @@ type Props = {
 
 export { generateMetadata };
 
-export async function generateStaticParams() {
-  const [slugs, parentSlug] = await Promise.all([
-    client.fetch(fetchAllDistributionMovieSlugs),
-    client.fetch(fetchDistributionParentSlug),
-  ]);
-
-  if (!parentSlug?.slug) {
-    console.error('No parent distribution page found');
-    return [];
-  }
-
-  return slugs.map(({ slug }) => ({
-    slug: parentSlug.slug,
-    movieSlug: slug,
-  }));
-}
-
 export default async function MoviePage({ params }: Props) {
   const resolvedParams = await params;
-  const { isEnabled } = await draftMode();
-  const movie: FetchDistributionMovieResult = await client.fetch(
-    fetchDistributionMovie,
-    { slug: resolvedParams.movieSlug },
-    isEnabled
-      ? {
-          perspective: 'previewDrafts',
-          useCdn: false,
-          stega: true,
-          token: token,
-        }
-      : undefined
-  );
+  const { data: movie }: { data: FetchDistributionMovieResult } =
+    await sanityFetch({
+      query: fetchDistributionMovie,
+      params: { slug: resolvedParams.movieSlug },
+    });
 
-  const settings = await client.fetch<SettingsQueryResult>(settingsQuery);
+  const { data: settings } = await sanityFetch({ query: settingsQuery });
 
   if (!movie) {
     console.log('Movie not found for slug:', resolvedParams.movieSlug);

--- a/src/app/(page)/[slug]/[movieSlug]/page.tsx
+++ b/src/app/(page)/[slug]/[movieSlug]/page.tsx
@@ -5,6 +5,8 @@ import { FetchDistributionMovieResult } from '../../../../../sanity.types';
 import { generateMetadata } from '@/utils/generateMetadata';
 import MovieDetailHero from '@/components/Blocks/DistributionList/DistributionMovieDetail/MovieDetailHero';
 import MovieDetail from '@/components/Blocks/DistributionList/DistributionMovieDetail/MovieDetail';
+import JsonLd from '@/components/JsonLd';
+import { getMovieJsonLd } from '@/utils/jsonld';
 
 type Props = {
   params: Promise<{ slug: string; movieSlug: string }>;
@@ -27,13 +29,28 @@ export default async function MoviePage({ params }: Props) {
     notFound();
   }
 
+  // JSON-LD structured data for Movie
+  const movieJsonLd = getMovieJsonLd({
+    title: movie.title || '',
+    description:
+      typeof movie.description === 'string' ? movie.description : undefined,
+    datePublished: movie.releaseDate || undefined,
+    duration: movie.duration || undefined,
+    actors: movie.actors?.map((a) => ({ name: a.actor })),
+    directors: movie.directors?.map((d) => ({ name: d.director })),
+    image: movie.moviePoster?.media?.asset?.url,
+  });
+
   return (
-    <main
-      id='movie-main-content'
-      className='relative flex flex-col flex-1 lg:pt-[20vh] lg:mt-[var(--header-height-desktop)]'
-    >
-      <MovieDetailHero {...movie} />
-      <MovieDetail movie={movie} settings={settings} />
-    </main>
+    <>
+      <JsonLd data={movieJsonLd} />
+      <main
+        id='movie-main-content'
+        className='relative flex flex-col flex-1 lg:pt-[20vh] lg:mt-[var(--header-height-desktop)]'
+      >
+        <MovieDetailHero {...movie} />
+        <MovieDetail movie={movie} settings={settings} />
+      </main>
+    </>
   );
 }

--- a/src/app/(page)/[slug]/layout.tsx
+++ b/src/app/(page)/[slug]/layout.tsx
@@ -7,14 +7,14 @@ import { DisableDraftMode } from '@/components/DisableDraftMode';
 import Footer from '@/components/Footer/Footer';
 import Header from '@/components/Header/Header';
 import { fetchFooter } from '@/sanity/lib/queries';
-import { client } from '@/sanity/lib/client';
+import { sanityFetch } from '@/sanity/lib/live';
 
 export default async function PageLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const footer = await client.fetch(fetchFooter);
+  const { data: footer } = await sanityFetch({ query: fetchFooter });
 
   return (
     <>

--- a/src/app/(page)/[slug]/page.tsx
+++ b/src/app/(page)/[slug]/page.tsx
@@ -1,8 +1,6 @@
-import { draftMode } from 'next/headers';
-import { client } from '@/sanity/lib/client';
-import { fetchAllPageSlugs, fetchPage } from '@/sanity/lib/queries';
+import { sanityFetch } from '@/sanity/lib/live';
+import { fetchPage } from '@/sanity/lib/queries';
 import { notFound } from 'next/navigation';
-import { token } from '@/sanity/lib/token';
 import { generateMetadata } from '@/utils/generateMetadata';
 import MediaCarousel from '@/components/Blocks/MediaCarousel';
 import ImageWithText from '@/components/Blocks/ImageWithText';
@@ -21,26 +19,12 @@ export type IPageBlockListItem = NonNullable<
 
 type PageParams = Promise<{ slug: string }>;
 
-export async function generateStaticParams() {
-  const slugs = await client.fetch(fetchAllPageSlugs);
-  return slugs.map(({ slug }) => ({ slug }));
-}
-
 export default async function Page({ params }: { params: PageParams }) {
   const { slug } = await params;
-  const { isEnabled } = await draftMode();
-  const data = await client.fetch(
-    fetchPage,
-    { slug },
-    isEnabled
-      ? {
-          perspective: 'previewDrafts',
-          useCdn: false,
-          stega: true,
-          token: token,
-        }
-      : undefined
-  );
+  const { data } = await sanityFetch({
+    query: fetchPage,
+    params: { slug },
+  });
   if (!data) {
     notFound();
   }

--- a/src/app/robots.txt/route.ts
+++ b/src/app/robots.txt/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(): Promise<NextResponse> {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_SANITY_STUDIO_PREVIEW_URL ||
+    'http://localhost:3000';
+  const robots = `User-agent: *\nAllow: /\nSitemap: ${baseUrl.replace(/\/$/, '')}/sitemap.xml`;
+  return new NextResponse(robots, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain',
+    },
+  });
+}

--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { sanityFetch } from '@/sanity/lib/live';
+import {
+  fetchAllPageSlugs,
+  fetchAllDistributionMovieSlugs,
+  fetchDistributionParentSlug,
+} from '@/sanity/lib/queries';
+
+export async function GET(): Promise<NextResponse> {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_SANITY_STUDIO_PREVIEW_URL ||
+    'http://localhost:3000';
+
+  // Fetch all page slugs
+  const { data: pages } = await sanityFetch({
+    query: fetchAllPageSlugs,
+  });
+  // Fetch all movie slugs
+  const { data: movies } = await sanityFetch({
+    query: fetchAllDistributionMovieSlugs,
+  });
+  // Fetch the parent slug for movies
+  const { data: parent } = await sanityFetch({
+    query: fetchDistributionParentSlug,
+  });
+  const movieParentSlug = parent?.slug || 'movies';
+
+  const urls = [
+    '', // homepage
+    ...pages.map((p) => p.slug),
+    ...movies.map((m) => `${movieParentSlug}/${m.slug}`),
+  ];
+
+  const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls
+  .map(
+    (slug) =>
+      `  <url>\n    <loc>${baseUrl.replace(/\/$/, '')}/${slug?.replace(/^\/+/, '')}</loc>\n  </url>`
+  )
+  .join('\n')}
+</urlset>`;
+
+  return new NextResponse(sitemap, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  });
+}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import MobileMenuBar from './MobileMenuBar/MobileMenuBar';
 
-import { client } from '@/sanity/lib/client';
+import { sanityFetch } from '@/sanity/lib/live';
 import { fetchHeader } from '@/sanity/lib/queries';
 import HeaderLogo from './HeaderLogo';
 import BlurDown from './MobileMenuBar/BlurDown';
@@ -12,7 +12,7 @@ type IHeader = {
 };
 
 const Header = async ({ isLandingPage = false }: IHeader) => {
-  const header = await client.fetch(fetchHeader);
+  const { data: header } = await sanityFetch({ query: fetchHeader });
 
   return (
     <>

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+type JsonLdProps = {
+  data: Record<string, unknown>;
+};
+
+const JsonLd: React.FC<JsonLdProps> = ({ data }) => (
+  <script
+    type='application/ld+json'
+    suppressHydrationWarning
+    dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+  />
+);
+
+export default JsonLd;

--- a/src/utils/generateMetadata.ts
+++ b/src/utils/generateMetadata.ts
@@ -6,7 +6,7 @@ import {
   settingsQuery,
   fetchDistributionMovie,
 } from '@/sanity/lib/queries';
-import { client } from '@/sanity/lib/client';
+import { sanityFetch } from '@/sanity/lib/live';
 import type {
   FetchHomeResult,
   SettingsQueryResult,
@@ -76,18 +76,19 @@ export async function generateMetadata(
     'http://localhost:3000';
 
   // Handle regular pages
-  const settings = await client.fetch<SettingsQueryResult>(settingsQuery);
+  const { data: settings } = await sanityFetch({ query: settingsQuery });
 
-  const page = isHome
-    ? await client.fetch<FetchHomeResult>(fetchHome, { slug: '/' })
-    : await client.fetch<FetchPageResult>(fetchPage, { slug });
+  const { data: page } = isHome
+    ? await sanityFetch({ query: fetchHome, params: { slug: '/' } })
+    : await sanityFetch({ query: fetchPage, params: { slug } });
 
   // Handle distribution movie pages
-  const movie: FetchDistributionMovieResult | undefined = isDistributionMovie
-    ? await client.fetch(fetchDistributionMovie, {
-        slug: movieSlug,
+  const { data: movie } = isDistributionMovie
+    ? await sanityFetch({
+        query: fetchDistributionMovie,
+        params: { slug: movieSlug },
       })
-    : undefined;
+    : { data: undefined };
 
   const pageSeo = page?.seo;
   const settingsSeo = settings?.seo;

--- a/src/utils/jsonld.ts
+++ b/src/utils/jsonld.ts
@@ -1,0 +1,46 @@
+// Helper for Organization JSON-LD
+export function getOrganizationJsonLd({
+  name,
+  url,
+}: {
+  name: string;
+  url: string;
+}) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name,
+    url,
+  };
+}
+
+// Helper for Movie JSON-LD
+export function getMovieJsonLd({
+  title,
+  description,
+  datePublished,
+  duration,
+  actors,
+  directors,
+  image,
+}: {
+  title: string;
+  description?: string;
+  datePublished?: string;
+  duration?: string;
+  actors?: { name: string | null }[];
+  directors?: { name: string | null }[];
+  image?: string;
+}) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Movie',
+    name: title,
+    description,
+    datePublished,
+    duration: duration ? `PT${duration}M` : undefined,
+    actor: actors?.map((a) => ({ '@type': 'Person', name: a.name })),
+    director: directors?.map((d) => ({ '@type': 'Person', name: d.name })),
+    image,
+  };
+}


### PR DESCRIPTION
- Updated multiple components and pages to utilize the new sanityFetch function instead of client.fetch.
- Simplified data fetching logic across Home, Page, and Movie components.
- Removed draftMode and token handling from fetch calls to streamline the codebase.

- Integrated JsonLd component to include structured data for Organization on the Home page and for Movies on the Movie page.
- Utilized getOrganizationJsonLd and getMovieJsonLd utility functions to generate appropriate JSON-LD data.
- Enhanced SEO and data representation for better search engine visibility.